### PR TITLE
Clean up url creation for new posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -295,6 +295,8 @@ class CreateForm(Form):
 		# Cleans the url and corrects various errors.
 		# Remove multiple spaces and leading and trailing spaces
 		pageStub = re.sub('[ ]{2,}', ' ', url).strip()
+		# Changes spaces to underscores and make everything lowercase
+		pageStub = pageStub.lower().replace(' ', '_')
 		return pageStub
 
 class SearchForm(Form):


### PR DESCRIPTION
This does 2 things, hence 2 commits.

1) Cleans up some simple errors. Multiple spaces and trailing and leading whitespace.

2) This is a bit stylistic, but makes urls lowercase (to reduce the change of dupes) and changes spaces to underscores for better url creation.   If you don't want the lowercase, I could understand (and I can remove), but I think for small to mid-sized wikis it's a good thing to have.
