### PR TITLE
Add cancel option to edit page

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -12,6 +12,7 @@ Wiki Editor
 	{{ input(form.tags, placeholder="Tags (comma separated)", class="span7") }}
 	<div class="form-actions">
 		<div class="pull-right">
+			<a href="{{ '/' + page.url }}">Cancel Edit</a>
 			<button class="btn" type="submit">Preview</button>
 			<button class="btn btn-success" type="submit">Save</button>
 		</div>


### PR DESCRIPTION
Currently the only way to cancel an edit is to press the back button. Although the back button works, there should be an explicit cancel. This is the simplest implementation I could think of.
