### PR TITLE
Fix bug in delete_user

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,7 +231,7 @@ class UserManager(object):
 
 	def delete_user(self, name):
 		users = self.read()
-		if not self.pop(name):
+		if not users.pop(name, False):
 			return False
 		self.write(users)
 		return True


### PR DESCRIPTION
It appears there is a bug in UserManager.delete_user. The code creates the appearance that attempting to delete a nonexistent user will return False, when in fact the method always raises a AttributeError. This version returns False when attempting to delete a nonexistent user and True when attempting to delete a real user.
