### PR TITLE
Load pages with universal newlines (mode 'rU')

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ class Page(object):
 			self.render()
 
 	def load(self):
-		with open(self.path) as f:
+		with open(self.path, 'rU') as f:
 			self.content = f.read().decode('utf-8')
 
 	def render(self):


### PR DESCRIPTION
If you manually add a document to the content directory which has \r\n endings throughout and then go to /index you will raise an IndexError on the line that says:

`self.body = self.content.split('\n\n')[1]`

Loading the content with universal newlines fixes that problem.

I'm working on other improvements to the handling of externally generated content, but that is a battle for another day.
