### PR TITLE
URGENT: Fix inadvertent body truncation when loading files with extra newlines

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def convertMarkdown(content):
 	# and adds meta
 	md = markdown.Markdown(['codehilite', 'fenced_code', 'meta'])
 	html = md.convert(content)
-	body = content.split('\n\n')[1]
+	body = content.split('\n\n', 1)[1]
 	meta = md.Meta
 	return html, body, meta
 


### PR DESCRIPTION
(See comment following the commit.)

Pretty trivial. Had to wait for the merge of the UI enhancements by @traeblain.

The basic idea is that the current implementation assumes that `'\n\n'` occurs only between the header and the content. But if you deposit existing content that was authored in a posix environment, the paragraphs will be separated by newlines instead of carriage return/newline combinations. The result is truncation during the loading of such content.
