### PR TITLE
Sort tags in tags.html

### DIFF
--- a/templates/tags.html
+++ b/templates/tags.html
@@ -12,10 +12,10 @@
 			</tr>
 		</thead>
 		<tbody>
-			{% for tag in tags %}
+			{% for tag, pages in tags|dictsort %}
 				<tr>
 					<td><a href="{{ url_for('tag', name=tag) }}">{{ tag }}</a></td>
-					<td>{{ tags[tag]|length }}</td>
+					<td>{{ pages|length }}</td>
 				</tr>
 			{% endfor %}
 		</tbody>


### PR DESCRIPTION
Trivial implementation of valuable feature. It was getting painful to look at all our tags in dict order.
