### PR TITLE
fix: markdown file show ctrl-m character on text editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ class Page(object):
                 line = u'%s: %s\n' % (key, value)
                 f.write(line.encode('utf-8'))
             f.write('\n'.encode('utf-8'))
-            f.write(self.body.encode('utf-8'))
+            f.write(self.body.replace('\r\n', os.linesep).encode('utf-8'))
         if update:
             self.load()
             self.render()


### PR DESCRIPTION
> HTTP/1.1 defines the sequence CR LF as the end-of-line marker for all protocol elements except the entity-body

Reference:
http://stackoverflow.com/questions/6324167/do-browsers-send-r-n-or-n-or-does-it-depend-on-the-browser 
http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2

So the textarea will get body with \r\n line end, it cause show ^M character When you want use editor open the markdown file on Unix.

``` python
f.write(self.body.replace('\r\n', os.linesep).encode('utf-8'))
```

Replace all '\r\n' characters with os.linesep in self.body can fix show ^M character on all platform .
