### PR TITLE
Added Wikilinks support 

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,11 @@ class Processors(object):
 
         Kwargs:
             None
+
+        Syntax: This accepts Wikilink syntax in the form of [[WikiLink]] or
+        [[url/location|LinkName]].  Everything is referenced from the base
+        location "/", therefore sub-pages need to use the
+        [[page/subpage|Subpage]].
         """
         link = r"((?<!\<code\>)\[\[([^<].+?) \s*([|] \s* (.+?) \s*)?]])"
         compLink = re.compile(link, re.X | re.U)


### PR DESCRIPTION
This takes care of issue #17...finally...

There are many things going on with this pull request so let me explain so that if a dialog is necessary, everyone will be fully informed.

As I stated in issue #17, using the default WikiLinks support that is packaged with Markdown was insufficient.  Using the SemanticWikiLinks extension was also insufficient and the function you use to alter the link had some problems. (By the way found out that depending upon your configuration you might be using pure python Element or a faster one based on a C module, so you end up having to put in the traps for both...bit of a pain.)  So I rolled my own.

Let's start with the Processor class.  When rolling my own, I realized it would be nice to have something that you could execute after Markdown has done it's job.  This way all the WikiLinks are left untouched and you won't have to worry about code blocks (since Pygments "obfuscates" them a bit).  For that matter, why not have something available/capable to do something prior to Markdown doing it's job.  So a new class was made (Processors). So WikiLinks and Mardown obviously go in this class, but I also figured the urlcleaner can as well since it's used now in areas other than the Form.  Other future pre/post processor now have a home.

The WikiLinks works well, it ignores code blocks as well as inline code.  The one area it fails is if I use `Text [[WikiLink]]` because that is hard to check, but does fine with `[[WikiLink]]`.  I figure that's a highly specific use-case and having the functionality outweighed this specific case.

I'm ready to answer any and all questions.  Let me know.
