### PR TITLE
Add Multi-Markdown Table Support

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,7 +104,7 @@ class Processors(object):
         """Final content output.  Processes the Markdown, post-processes, and
         Meta data.
         """
-        md = markdown.Markdown(['codehilite', 'fenced_code', 'meta'])
+        md = markdown.Markdown(['codehilite', 'fenced_code', 'meta', 'tables'])
         html = md.convert(self.content)
         phtml = self.post(html)
         body = self.content.split('\n\n', 1)[1]


### PR DESCRIPTION
Just wondering if table support (besides inline HTML tables) would be on the radar. I just added `'tables'` to the markdown object, and that seemed to be all that was necessary.

Line 107

Is:

``` python
md = markdown.Markdown(['codehilite', 'fenced_code', 'meta'])
```

Suggested:

``` python
md = markdown.Markdown(['codehilite', 'fenced_code', 'meta', 'tables'])
```
