### PR TITLE
Change Textarea (for editing) to Monospace Font

### DIFF
--- a/static/bootstrap.css
+++ b/static/bootstrap.css
@@ -777,9 +777,11 @@ textarea {
 }
 input,
 button,
-select,
-textarea {
+select {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+textarea {
+  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 }
 label {
   display: block;


### PR DESCRIPTION
Editing (via textarea) Markdown seems easier/clearer with a monospaced font. This is especially true if one enables Multi-Markdown table support.

Beginning with Line 778...

_**Currently**_

``` css
input,
button,
select,
textarea {
  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
}
```

_**Proposed**_

``` css
input,
button,
select {
  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
}
textarea {
  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
}
```
