### PR TITLE
don't crash on markdown files without title or tags (fixes #37)

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,7 +166,10 @@ class Page(object):
 
     @property
     def title(self):
-        return self['title']
+        try:
+            return self['title']
+        except KeyError:
+            return self.url
 
     @title.setter
     def title(self, value):
@@ -174,7 +177,10 @@ class Page(object):
 
     @property
     def tags(self):
-        return self['tags']
+        try:
+            return self['tags']
+        except KeyError:
+            return ""
 
     @tags.setter
     def tags(self, value):


### PR DESCRIPTION
PR for issue #37 

If there is no title, I am returning the filename. If there are no tags, just an empty string. 
The implementation uses the pythonic try/except way. If you prefer, I can of course change that to "if 'title' in self.meta... "
