### PR TITLE
Turning `content` directory definition into unicode type.

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from flask.ext.script import Manager
 """
 
 app = Flask(__name__)
-app.config['CONTENT_DIR'] = 'content'
+app.config['CONTENT_DIR'] = u'content'
 app.config['TITLE'] = 'wiki'
 try:
     app.config.from_pyfile(


### PR DESCRIPTION
The page names (file names) with non ascii characters inside are not rendered by jinja (unicode decode error raises), because the `os.listdir()` function returns `str` types if `str` argument was given.