### PR TITLE
allow host to be passed as a command line input

### DIFF
--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,6 +26,7 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
+@click.option('--host', default='')
 @click.pass_context
 def web(ctx, debug):
     """
@@ -36,4 +37,4 @@ def web(ctx, debug):
             mode.
     """
     app = create_app(ctx.meta['directory'])
-    app.run(debug=debug)
+    app.run(debug=debug, host=host)

--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,7 +26,7 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
-@click.option('--host', default='')
+@click.option('--host', default=None)
 @click.pass_context
 def web(ctx, debug):
     """


### PR DESCRIPTION
Currently, there is no way to make the wiki externally visible.  i.e. other computers on the network cannot view the wiki.  Flask will make a server externally visible if the host value is set to '0.0.0.0'.  i.e.  app.run(host='0.0.0.0')

This pull request will allow the user to make the wiki externally visible by entering "wiki web --host='0.0.0.0'"