### PR TITLE
Adding host and port args to cli

### DIFF
--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,8 +26,8 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
-@click.option('--host', envvar='HOST', default=None)
-@click.option('--port', envvar='PORT', default=None, type=int)
+@click.option('--host', envvar='WIKI_HOST', default=None)
+@click.option('--port', envvar='WIKI_PORT', default=None, type=int)
 @click.pass_context
 def web(ctx, debug, host, port):
     """
@@ -36,9 +36,9 @@ def web(ctx, debug, host, port):
         \b
         :param bool debug: whether or not to run the web app in debug
             mode.
-        :param str  host: Set the host to 0.0.0.0 to connect from outside 
-            defaults to 127.0.0.1.
-        :param int  port: Set the listening port defaults to 5000.
+        :param str host: Set the host to 0.0.0.0 to connect from outside. 
+            The default is 127.0.0.1.
+        :param int port: Set the listening port. The default is 5000.
     """
     app = create_app(ctx.meta['directory'])
     app.run(debug=debug, host=host, port=port)

--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,14 +26,19 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
+@click.option('--host', envvar='HOST', default=None)
+@click.option('--port', envvar='PORT', default=None, type=int)
 @click.pass_context
-def web(ctx, debug):
+def web(ctx, debug, host, port):
     """
         Run the web app.
 
         \b
         :param bool debug: whether or not to run the web app in debug
             mode.
+        :param str  host: Set the host to 0.0.0.0 to connect from outside 
+            defaults to 127.0.0.1.
+        :param int  port: Set the listening port defaults to 5000.
     """
     app = create_app(ctx.meta['directory'])
-    app.run(debug=debug)
+    app.run(debug=debug, host=host, port=port)


### PR DESCRIPTION
This pull request addresses issue #73, it adds the ability to set the host via the command line (--host) and I also added the option to set the port (--port) while I was in there. If I need to change or fix anything let me know :)