### PR TITLE
Fix the failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
-install: "python setup.py develop"
+install: "pip install --upgrade pip setuptools wheel && python setup.py develop"
 # command to run tests
 script: "python setup.py test"
 # disable notification emails

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,24 +3,31 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
+      PYTHON_VERSION: "2.7.14"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.5"
+      PYTHON_VERSION: "3.3.7"
       PYTHON_ARCH: "32"
-
+    
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
+      PYTHON_VERSION: "3.4.8"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.5"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.3"
+      PYTHON_ARCH: "32"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "python setup.py develop"
+  - "pip install --upgrade pip setuptools wheel && python setup.py develop"
 
 test_script:
   - "python setup.py test"


### PR DESCRIPTION
A fix for issue #75 that I opened earlier. This updates setuptools before running the tests which was causing some of the tests to fail. Also added python version 3.6 to both travis and appveyor.