### PR TITLE
Patch appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ init:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install --upgrade pip setuptools wheel && python setup.py develop"
+  - "pip install --upgrade setuptools wheel && python setup.py develop"
 
 test_script:
   - "python setup.py test"

--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,8 +26,8 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
-@click.option('--host', envvar='HOST', default=None)
-@click.option('--port', envvar='PORT', default=None, type=int)
+@click.option('--host', envvar='WIKI_HOST', default=None)
+@click.option('--port', envvar='WIKI_PORT', default=None, type=int)
 @click.pass_context
 def web(ctx, debug, host, port):
     """
@@ -36,9 +36,9 @@ def web(ctx, debug, host, port):
         \b
         :param bool debug: whether or not to run the web app in debug
             mode.
-        :param str  host: Set the host to 0.0.0.0 to connect from outside 
-            defaults to 127.0.0.1.
-        :param int  port: Set the listening port defaults to 5000.
+        :param str host: Set the host to 0.0.0.0 to connect from outside. 
+            The default is 127.0.0.1.
+        :param int port: Set the listening port. The default is 5000.
     """
     app = create_app(ctx.meta['directory'])
     app.run(debug=debug, host=host, port=port)

--- a/wiki/cli.py
+++ b/wiki/cli.py
@@ -26,14 +26,19 @@ def main(ctx, directory):
 
 @main.command()
 @click.option('--debug/--no-debug', envvar='WIKI_DEBUG', default=False)
+@click.option('--host', envvar='HOST', default=None)
+@click.option('--port', envvar='PORT', default=None, type=int)
 @click.pass_context
-def web(ctx, debug):
+def web(ctx, debug, host, port):
     """
         Run the web app.
 
         \b
         :param bool debug: whether or not to run the web app in debug
             mode.
+        :param str  host: Set the host to 0.0.0.0 to connect from outside 
+            defaults to 127.0.0.1.
+        :param int  port: Set the listening port defaults to 5000.
     """
     app = create_app(ctx.meta['directory'])
-    app.run(debug=debug)
+    app.run(debug=debug, host=host, port=port)


### PR DESCRIPTION
For some reason appveyor seems to have stopped allowing pip to update. Removed updating pip and now the tests are working again.