### PR TITLE
Sanitize move's newurl with clean_url.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -293,3 +293,17 @@ class WikiTestCase(WikiBaseTestCase):
 
         testpage = pages[1]
         assert testpage.url == 'test'
+
+    def test_move(self):
+        """
+            Assert that pages are moved correctly, including URL sanitization.
+        """
+        self.create_file('test.md')
+        assert self.wiki.move('test', 'newtest') == 'newtest'
+        assert self.wiki.exists('newtest')
+        assert not self.wiki.exists('test')
+
+        self.create_file('test_2.md')
+        assert self.wiki.move('test_2', 'Test 3') == "test_3"
+        assert self.wiki.exists('test_3')
+        assert not self.wiki.exists('test_2')

--- a/wiki/core.py
+++ b/wiki/core.py
@@ -278,6 +278,7 @@ class Wiki(object):
         return Page(path, url, new=True)
 
     def move(self, url, newurl):
+        newurl = clean_url(newurl)
         source = os.path.join(self.root, url) + '.md'
         target = os.path.join(self.root, newurl) + '.md'
         # normalize root path (just in case somebody defined it absolute,
@@ -297,6 +298,7 @@ class Wiki(object):
         if not os.path.exists(folder):
             os.makedirs(folder)
         os.rename(source, target)
+        return newurl
 
     def delete(self, url):
         path = self.path(url)

--- a/wiki/web/routes.py
+++ b/wiki/web/routes.py
@@ -90,8 +90,8 @@ def move(url):
     form = URLForm(obj=page)
     if form.validate_on_submit():
         newurl = form.url.data
-        current_wiki.move(url, newurl)
-        return redirect(url_for('wiki.display', url=newurl))
+        renamed = current_wiki.move(url, newurl)
+        return redirect(url_for('wiki.display', url=renamed))
     return render_template('move.html', form=form, page=page)
 
 


### PR DESCRIPTION
This fixes a bug where the user can move a page to a new name that has
uppercase and spaces and is no longer reachable.